### PR TITLE
Add standalone Terraform metadata

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,17 +1,3 @@
-# Standalone examples and fixtures inherit compatibility from the module.
-rule "terraform_required_providers" {
-  enabled = false
-}
-
-rule "terraform_required_version" {
-  enabled = false
-}
-
-# Fixture variable typing is tracked separately from lint tooling.
-rule "terraform_typed_variables" {
-  enabled = false
-}
-
 # Retained compatibility declarations are tracked separately from lint tooling.
 rule "terraform_unused_declarations" {
   enabled = false

--- a/examples/generic_s3/README.md
+++ b/examples/generic_s3/README.md
@@ -10,7 +10,7 @@ Example shows using Default Tags in the provider as well as passing additional t
 
 ```hcl
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {
@@ -46,7 +46,7 @@ output "example-generic-s3" { value = module.example-generic-s3 }
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers

--- a/examples/generic_s3/README.md
+++ b/examples/generic_s3/README.md
@@ -9,6 +9,17 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -33,7 +44,10 @@ output "example-generic-s3" { value = module.example-generic-s3 }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 

--- a/examples/generic_s3/example.tf
+++ b/examples/generic_s3/example.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {

--- a/examples/generic_s3/example.tf
+++ b/examples/generic_s3/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/generic_s3_object/README.md
+++ b/examples/generic_s3_object/README.md
@@ -9,6 +9,17 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -46,7 +57,10 @@ output "example-generic-object" { value = module.example-generic-object }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 

--- a/examples/generic_s3_object/README.md
+++ b/examples/generic_s3_object/README.md
@@ -10,7 +10,7 @@ Example shows using Default Tags in the provider as well as passing additional t
 
 ```hcl
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {
@@ -59,7 +59,7 @@ output "example-generic-object" { value = module.example-generic-object }
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers

--- a/examples/generic_s3_object/example.tf
+++ b/examples/generic_s3_object/example.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {

--- a/examples/generic_s3_object/example.tf
+++ b/examples/generic_s3_object/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/lb_access_log_bucket/README.md
+++ b/examples/lb_access_log_bucket/README.md
@@ -9,6 +9,17 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -35,7 +46,10 @@ output "example-lb-logging-bucket" { value = module.example-lb-logging-bucket }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 

--- a/examples/lb_access_log_bucket/README.md
+++ b/examples/lb_access_log_bucket/README.md
@@ -10,7 +10,7 @@ Example shows using Default Tags in the provider as well as passing additional t
 
 ```hcl
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {
@@ -48,7 +48,7 @@ output "example-lb-logging-bucket" { value = module.example-lb-logging-bucket }
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers

--- a/examples/lb_access_log_bucket/example.tf
+++ b/examples/lb_access_log_bucket/example.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {

--- a/examples/lb_access_log_bucket/example.tf
+++ b/examples/lb_access_log_bucket/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -10,7 +10,7 @@ Example shows using Default Tags in the provider as well as passing additional t
 
 ```hcl
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {
@@ -75,7 +75,7 @@ output "example-generic-s3-west" { value = module.example-generic-s3-west }
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -9,6 +9,17 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "us-east-1"
   default_tags {
@@ -62,7 +73,10 @@ output "example-generic-s3-west" { value = module.example-generic-s3-west }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 

--- a/examples/multi-region/example.tf
+++ b/examples/multi-region/example.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {

--- a/examples/multi-region/example.tf
+++ b/examples/multi-region/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "us-east-1"
   default_tags {

--- a/examples/s3_logging_bucket/README.md
+++ b/examples/s3_logging_bucket/README.md
@@ -9,6 +9,17 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -49,7 +60,10 @@ output "example-bucket" { value = module.example-bucket }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 

--- a/examples/s3_logging_bucket/README.md
+++ b/examples/s3_logging_bucket/README.md
@@ -10,7 +10,7 @@ Example shows using Default Tags in the provider as well as passing additional t
 
 ```hcl
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {
@@ -62,7 +62,7 @@ output "example-bucket" { value = module.example-bucket }
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers

--- a/examples/s3_logging_bucket/example.tf
+++ b/examples/s3_logging_bucket/example.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {

--- a/examples/s3_logging_bucket/example.tf
+++ b/examples/s3_logging_bucket/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/with_acl_grants/README.md
+++ b/examples/with_acl_grants/README.md
@@ -9,6 +9,17 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 data "aws_canonical_user_id" "current" {}
 
 module "acl-s3" {
@@ -43,13 +54,16 @@ output "acl-s3" { value = module.acl-s3 }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.35.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0 |
 
 ## Modules
 

--- a/examples/with_acl_grants/README.md
+++ b/examples/with_acl_grants/README.md
@@ -10,7 +10,7 @@ Example shows using Default Tags in the provider as well as passing additional t
 
 ```hcl
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {
@@ -56,14 +56,14 @@ output "acl-s3" { value = module.acl-s3 }
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 

--- a/examples/with_acl_grants/example.tf
+++ b/examples/with_acl_grants/example.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {

--- a/examples/with_acl_grants/example.tf
+++ b/examples/with_acl_grants/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 data "aws_canonical_user_id" "current" {}
 
 module "acl-s3" {

--- a/examples/with_cors/README.md
+++ b/examples/with_cors/README.md
@@ -9,6 +9,17 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -43,7 +54,10 @@ output "example-with-cors" { value = module.example-with-cors }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 

--- a/examples/with_cors/README.md
+++ b/examples/with_cors/README.md
@@ -10,7 +10,7 @@ Example shows using Default Tags in the provider as well as passing additional t
 
 ```hcl
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {
@@ -56,7 +56,7 @@ output "example-with-cors" { value = module.example-with-cors }
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers

--- a/examples/with_cors/example.tf
+++ b/examples/with_cors/example.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {

--- a/examples/with_cors/example.tf
+++ b/examples/with_cors/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/test/acl/acl.tf
+++ b/test/acl/acl.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.7"
 
   required_providers {
     aws = {

--- a/test/acl/acl.tf
+++ b/test/acl/acl.tf
@@ -1,11 +1,25 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 variable "name" {
+  type    = string
   default = "basic-usage-default-s3"
 }
 variable "bucket_prefix" {
+  type    = string
   default = "acl-test"
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }

--- a/test/basic-usage/basic-usage.tf
+++ b/test/basic-usage/basic-usage.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.7"
 
   required_providers {
     aws = {

--- a/test/basic-usage/basic-usage.tf
+++ b/test/basic-usage/basic-usage.tf
@@ -1,8 +1,21 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 variable "name" {
+  type    = string
   default = "default-s3"
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }

--- a/test/bucket-name-override/bucket-name-override.tf
+++ b/test/bucket-name-override/bucket-name-override.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.7"
 
   required_providers {
     aws = {

--- a/test/bucket-name-override/bucket-name-override.tf
+++ b/test/bucket-name-override/bucket-name-override.tf
@@ -1,9 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }
 }
 variable "bucket_name_override" {
+  type    = string
   default = "override-default-s3"
 }
 

--- a/test/bucket-prefix/bucket-prefix.tf
+++ b/test/bucket-prefix/bucket-prefix.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.7"
 
   required_providers {
     aws = {

--- a/test/bucket-prefix/bucket-prefix.tf
+++ b/test/bucket-prefix/bucket-prefix.tf
@@ -1,13 +1,27 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 variable "name" {
+  type    = string
   default = "default-s3"
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }
 }
 variable "bucket_prefix" {
+  type    = string
   default = "prefix"
 }
 

--- a/test/options/options.tf
+++ b/test/options/options.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.7"
 
   required_providers {
     aws = {

--- a/test/options/options.tf
+++ b/test/options/options.tf
@@ -1,13 +1,27 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 variable "name" {
+  type    = string
   default = "default-s3"
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }
 }
 variable "bucket_prefix" {
+  type    = string
   default = "options"
 }
 


### PR DESCRIPTION
## Summary

- declare compatible Terraform and provider requirements in standalone examples and fixtures
- add explicit types to fixture and example variables where needed
- regenerate affected example documentation
- remove only the TFLint exceptions resolved by this change

## Validation

- `terraform fmt -check -recursive`
- `tflint --recursive --config "$(pwd)/.tflint.hcl"`
- `terraform init -backend=false`
- `terraform validate`
- standalone example and fixture `terraform init` / `terraform validate`
- terraform-docs output checks

Tracking: SO1-119