### PR TITLE
Handle typed empty S3 grant lists

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -2,8 +2,3 @@
 rule "terraform_unused_declarations" {
   enabled = false
 }
-
-# Collection behavior changes require focused tests and a separate review.
-rule "terraform_empty_list_equality" {
-  enabled = false
-}

--- a/locals.tf
+++ b/locals.tf
@@ -9,7 +9,7 @@ locals {
   }
   encryption = merge(local.encryption_defaults, var.encryption)
 
-  access_control_policy_grants = var.access_control_policy_grants != [] ? { enabled = var.access_control_policy_grants } : {}
+  access_control_policy_grants = length(var.access_control_policy_grants) > 0 ? { enabled = var.access_control_policy_grants } : {}
   accelerate_status            = var.accelerate_status != null ? { enabled = var.accelerate_status } : {}
   bucket_policy                = var.bucket_policy != null ? { enabled = var.bucket_policy } : {}
   canned_acl                   = var.canned_acl != null ? { enabled = var.canned_acl } : {}

--- a/test/basic-usage/basic-usage.tf
+++ b/test/basic-usage/basic-usage.tf
@@ -42,8 +42,9 @@ locals {
 module "generic-s3" {
   source = "../../"
 
-  name = var.name
-  tags = var.tags
+  name                         = var.name
+  access_control_policy_grants = tolist([])
+  tags                         = var.tags
 }
 output "generic-s3" { value = module.generic-s3 }
 

--- a/test/basic-usage/basic-usage.tftest.hcl
+++ b/test/basic-usage/basic-usage.tftest.hcl
@@ -66,6 +66,6 @@ run "verify_basic_usage_s3_outputs_plan" {
   }
   assert {
     condition     = module.generic-s3.access_control_policy_module == {}
-    error_message = "Access Control Policy does not match expected result."
+    error_message = "A typed empty grant list should not create an Access Control Policy module."
   }
 }


### PR DESCRIPTION
## Summary

- replace the type-sensitive empty-list equality with an explicit grant-count check
- add a regression case that passes a typed empty list and verifies no ACL submodule is created
- re-enable the resolved `terraform_empty_list_equality` TFLint rule

## Root cause and impact

Terraform collection equality includes collection type. A typed empty list is not equal to the untyped `[]` tuple literal, so the old comparison incorrectly created the access-control-policy submodule with no grants. The AWS provider then rejected the ACL resource because neither an access-control policy nor a canned ACL was present.

Using `length(...) > 0` preserves non-empty grant behavior while correctly treating every empty list representation as empty.

## Validation

- reproduced the pre-fix failure with `tolist([])`
- Terraform 1.7.5 root `init` and `validate`
- Terraform 1.7.5 native tests for all five fixtures
- focused typed-empty-list regression test
- focused non-empty ACL regression test
- `terraform fmt -check -recursive`
- TFLint 0.63.1 recursive check with the rule re-enabled
- `git diff --check`

Tracking: SO1-102