### PR TITLE
fix: honor retained S3 module inputs

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,4 +1,3 @@
-# Retained compatibility declarations are tracked separately from lint tooling.
 rule "terraform_unused_declarations" {
-  enabled = false
+  enabled = true
 }

--- a/modules/cors/cors.tf
+++ b/modules/cors/cors.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket_cors_configuration" "cors" {
-  bucket = var.bucket
+  bucket                = var.bucket
+  expected_bucket_owner = var.expected_bucket_owner
 
   dynamic "cors_rule" {
     for_each = var.cors_rules == null ? [] : var.cors_rules

--- a/modules/logging/logging.tf
+++ b/modules/logging/logging.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket_logging" "logging" {
-  bucket = var.bucket
+  bucket                = var.bucket
+  expected_bucket_owner = var.expected_bucket_owner
 
   target_bucket = var.target_bucket
   target_prefix = var.target_prefix

--- a/modules/s3_object_from_file/s3-object.tf
+++ b/modules/s3_object_from_file/s3-object.tf
@@ -22,6 +22,7 @@ resource "aws_s3_object" "object" {
   content_encoding    = var.content_encoding
   content_language    = var.content_language
   content_type        = var.content_type
+  website_redirect    = var.website_redirect
 
   tags = local.tags
 }

--- a/test/acl/acl.tf
+++ b/test/acl/acl.tf
@@ -39,8 +39,10 @@ data "aws_region" "current" {}
 data "aws_canonical_user_id" "current" {}
 
 locals {
-  region      = data.aws_region.current.id
-  account_id  = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.id
+  account_id = data.aws_caller_identity.current.account_id
+  # Consumed by acl.tftest.hcl, which TFLint does not trace.
+  # tflint-ignore: terraform_unused_declarations
   bucket_name = format("%s-%s-%s-%s", var.name, var.bucket_prefix, local.region, local.account_id)
 }
 #tfsec:ignore:AWS002 Not logging by default. Tests verify that logging is not enabled.

--- a/test/basic-usage/basic-usage.tf
+++ b/test/basic-usage/basic-usage.tf
@@ -34,8 +34,10 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  region      = data.aws_region.current.id
-  account_id  = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.id
+  account_id = data.aws_caller_identity.current.account_id
+  # Consumed by basic-usage.tftest.hcl, which TFLint does not trace.
+  # tflint-ignore: terraform_unused_declarations
   bucket_name = format("%s-%s-%s", var.name, local.region, local.account_id)
 }
 #tfsec:ignore:AWS002 Not logging by default. Tests verify that logging is not enabled.

--- a/test/bucket-name-override/bucket-name-override.tf
+++ b/test/bucket-name-override/bucket-name-override.tf
@@ -30,6 +30,8 @@ provider "aws" {
 }
 
 locals {
+  # Consumed by bucket-name-override.tftest.hcl, which TFLint does not trace.
+  # tflint-ignore: terraform_unused_declarations
   bucket_name = var.bucket_name_override
 }
 
@@ -37,7 +39,7 @@ locals {
 module "generic-s3-override" {
   source = "../../"
 
-  tags                 = { example = "true" }
+  tags                 = var.tags
   bucket_name_override = var.bucket_name_override
 }
 output "generic-s3-override" { value = module.generic-s3-override }

--- a/test/bucket-prefix/bucket-prefix.tf
+++ b/test/bucket-prefix/bucket-prefix.tf
@@ -38,8 +38,10 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  region      = data.aws_region.current.id
-  account_id  = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.id
+  account_id = data.aws_caller_identity.current.account_id
+  # Consumed by bucket-prefix.tftest.hcl, which TFLint does not trace.
+  # tflint-ignore: terraform_unused_declarations
   bucket_name = format("%s-%s-%s-%s", var.name, var.bucket_prefix, local.region, local.account_id)
 }
 #tfsec:ignore:AWS002 Not logging by default. Tests verify that logging is not enabled.

--- a/test/options/options.tf
+++ b/test/options/options.tf
@@ -38,8 +38,10 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  region      = data.aws_region.current.id
-  account_id  = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.id
+  account_id = data.aws_caller_identity.current.account_id
+  # Consumed by options.tftest.hcl, which TFLint does not trace.
+  # tflint-ignore: terraform_unused_declarations
   bucket_name = format("%s-%s-%s-%s", var.name, var.bucket_prefix, local.region, local.account_id)
 }
 


### PR DESCRIPTION
## Summary

- pass `expected_bucket_owner` through the CORS and logging submodules
- pass `website_redirect` through the object-from-file submodule
- use the declared tags input in the name-override fixture
- retain test-only bucket-name locals with scoped ignores because Terraform test files consume them outside TFLint's reference graph
- re-enable the audited `terraform_unused_declarations` rule

The public inputs were retained because deleting them would be breaking; this change restores the behavior their existing documentation promises.

## Validation

- TFLint 0.63.1 recursive scan
- Terraform 1.7.5 formatting and validation
- 5 fixture native tests